### PR TITLE
Feature implementation from commits 11522a0..0ff4bb4

### DIFF
--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestCompare(t *testing.T) {
+	t.Parallel()
+
 	type customString string
 	type customInt int
 	type customInt8 int8
@@ -127,6 +129,8 @@ func callerName(skip int) string {
 }
 
 func TestGreater(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Greater(mockT, 2, 1) {
@@ -171,6 +175,8 @@ func TestGreater(t *testing.T) {
 }
 
 func TestGreaterOrEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !GreaterOrEqual(mockT, 2, 1) {
@@ -215,6 +221,8 @@ func TestGreaterOrEqual(t *testing.T) {
 }
 
 func TestLess(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Less(mockT, 1, 2) {
@@ -259,6 +267,8 @@ func TestLess(t *testing.T) {
 }
 
 func TestLessOrEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !LessOrEqual(mockT, 1, 2) {
@@ -303,6 +313,8 @@ func TestLessOrEqual(t *testing.T) {
 }
 
 func TestPositive(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Positive(mockT, 1) {
@@ -342,6 +354,8 @@ func TestPositive(t *testing.T) {
 }
 
 func TestNegative(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Negative(mockT, -1) {
@@ -381,6 +395,8 @@ func TestNegative(t *testing.T) {
 }
 
 func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
@@ -399,6 +415,8 @@ func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
 }
 
 func Test_compareTwoValuesNotComparableValues(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	type CompareStruct struct {
@@ -418,6 +436,8 @@ func Test_compareTwoValuesNotComparableValues(t *testing.T) {
 }
 
 func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
@@ -438,6 +458,8 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 }
 
 func Test_containsValue(t *testing.T) {
+	t.Parallel()
+
 	for _, currCase := range []struct {
 		values []compareResult
 		value  compareResult

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestIsIncreasing(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !IsIncreasing(mockT, []int{1, 2}) {
@@ -51,6 +53,8 @@ func TestIsIncreasing(t *testing.T) {
 }
 
 func TestIsNonIncreasing(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !IsNonIncreasing(mockT, []int{2, 1}) {
@@ -96,6 +100,8 @@ func TestIsNonIncreasing(t *testing.T) {
 }
 
 func TestIsDecreasing(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !IsDecreasing(mockT, []int{2, 1}) {
@@ -141,6 +147,8 @@ func TestIsDecreasing(t *testing.T) {
 }
 
 func TestIsNonDecreasing(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !IsNonDecreasing(mockT, []int{1, 2}) {
@@ -186,6 +194,8 @@ func TestIsNonDecreasing(t *testing.T) {
 }
 
 func TestOrderingMsgAndArgsForwarding(t *testing.T) {
+	t.Parallel()
+
 	msgAndArgs := []interface{}{"format %s %x", "this", 0xc001}
 	expectedOutput := "format this c001\n"
 	collection := []int{1, 2, 1}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1876,6 +1876,11 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid yaml.\nYAML parsing error: '%s'", expected, err.Error()), msgAndArgs...)
 	}
 
+	// Shortcut if same bytes
+	if actual == expected {
+		return true
+	}
+
 	if err := yaml.Unmarshal([]byte(actual), &actualYAMLAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid yaml.\nYAML error: '%s'", actual, err.Error()), msgAndArgs...)
 	}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -543,8 +543,9 @@ func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) b
 	if !same {
 		// both are pointers but not the same type & pointing to the same address
 		return Fail(t, fmt.Sprintf("Not same: \n"+
-			"expected: %p %#v\n"+
-			"actual  : %p %#v", expected, expected, actual, actual), msgAndArgs...)
+			"expected: %p %#[1]v\n"+
+			"actual  : %p %#[2]v",
+			expected, actual), msgAndArgs...)
 	}
 
 	return true
@@ -569,8 +570,8 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 
 	if same {
 		return Fail(t, fmt.Sprintf(
-			"Expected and actual point to the same object: %p %#v",
-			expected, expected), msgAndArgs...)
+			"Expected and actual point to the same object: %p %#[1]v",
+			expected), msgAndArgs...)
 	}
 	return true
 }

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1853,6 +1853,11 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
 	}
 
+	// Shortcut if same bytes
+	if actual == expected {
+		return true
+	}
+
 	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
 	}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2008,6 +2008,9 @@ type CollectT struct {
 	errors []error
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (CollectT) Helper() {}
+
 // Errorf collects the error.
 func (c *CollectT) Errorf(format string, args ...interface{}) {
 	c.errors = append(c.errors, fmt.Errorf(format, args...))

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -745,6 +745,9 @@ type bufferT struct {
 	buf bytes.Buffer
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (bufferT) Helper() {}
+
 func (t *bufferT) Errorf(format string, args ...interface{}) {
 	// implementation of decorate is copied from testing.T
 	decorate := func(s string) string {
@@ -2791,6 +2794,9 @@ type mockTestingT struct {
 	args     []interface{}
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (mockTestingT) Helper() {}
+
 func (m *mockTestingT) errorString() string {
 	return fmt.Sprintf(m.errorFmt, m.args...)
 }
@@ -2815,6 +2821,9 @@ func TestFailNowWithPlainTestingT(t *testing.T) {
 }
 
 type mockFailNowTestingT struct{}
+
+// Helper is like [testing.T.Helper] but does nothing.
+func (mockFailNowTestingT) Helper() {}
 
 func (m *mockFailNowTestingT) Errorf(format string, args ...interface{}) {}
 
@@ -3141,11 +3150,12 @@ type errorsCapturingT struct {
 	errors []error
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (errorsCapturingT) Helper() {}
+
 func (t *errorsCapturingT) Errorf(format string, args ...interface{}) {
 	t.errors = append(t.errors, fmt.Errorf(format, args...))
 }
-
-func (t *errorsCapturingT) Helper() {}
 
 func TestEventuallyWithTFalse(t *testing.T) {
 	t.Parallel()
@@ -3392,6 +3402,9 @@ type captureTestingT struct {
 	failed bool
 	msg    string
 }
+
+// Helper is like [testing.T.Helper] but does nothing.
+func (captureTestingT) Helper() {}
 
 func (ctt *captureTestingT) Errorf(format string, args ...interface{}) {
 	ctt.msg = fmt.Sprintf(format, args...)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -100,6 +100,8 @@ func (a *AssertionTesterConformingObject) TestMethod() {
 type AssertionTesterNonConformingObject struct{}
 
 func TestObjectsAreEqual(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		expected interface{}
 		actual   interface{}
@@ -135,6 +137,8 @@ func TestObjectsAreEqual(t *testing.T) {
 }
 
 func TestObjectsAreEqualValues(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 
 	cases := []struct {
@@ -205,6 +209,8 @@ type S6 struct {
 }
 
 func TestObjectsExportedFieldsAreEqual(t *testing.T) {
+	t.Parallel()
+
 	intValue := 1
 
 	cases := []struct {
@@ -278,6 +284,8 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 }
 
 func TestCopyExportedFields(t *testing.T) {
+	t.Parallel()
+
 	intValue := 1
 
 	cases := []struct {
@@ -365,6 +373,8 @@ func TestCopyExportedFields(t *testing.T) {
 }
 
 func TestEqualExportedValues(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		value1        interface{}
 		value2        interface{}
@@ -518,6 +528,8 @@ func TestEqualExportedValues(t *testing.T) {
 }
 
 func TestImplements(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
@@ -532,6 +544,8 @@ func TestImplements(t *testing.T) {
 }
 
 func TestNotImplements(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !NotImplements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
@@ -546,6 +560,8 @@ func TestNotImplements(t *testing.T) {
 }
 
 func TestIsType(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
@@ -557,6 +573,7 @@ func TestIsType(t *testing.T) {
 }
 
 func TestNotIsType(t *testing.T) {
+	t.Parallel()
 
 	mockT := new(testing.T)
 
@@ -569,6 +586,8 @@ func TestNotIsType(t *testing.T) {
 }
 
 func TestEqual(t *testing.T) {
+	t.Parallel()
+
 	type myType string
 
 	mockT := new(testing.T)
@@ -614,6 +633,8 @@ func ptr(i int) *int {
 }
 
 func TestSame(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if Same(mockT, ptr(1), ptr(1)) {
@@ -632,6 +653,8 @@ func TestSame(t *testing.T) {
 }
 
 func TestNotSame(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !NotSame(mockT, ptr(1), ptr(1)) {
@@ -650,6 +673,8 @@ func TestNotSame(t *testing.T) {
 }
 
 func Test_samePointers(t *testing.T) {
+	t.Parallel()
+
 	p := ptr(2)
 
 	type args struct {
@@ -757,6 +782,8 @@ func (t *bufferT) Errorf(format string, args ...interface{}) {
 }
 
 func TestStringEqual(t *testing.T) {
+	t.Parallel()
+
 	for i, currCase := range []struct {
 		equalWant  string
 		equalGot   string
@@ -772,6 +799,8 @@ func TestStringEqual(t *testing.T) {
 }
 
 func TestEqualFormatting(t *testing.T) {
+	t.Parallel()
+
 	for i, currCase := range []struct {
 		equalWant  string
 		equalGot   string
@@ -790,6 +819,8 @@ func TestEqualFormatting(t *testing.T) {
 }
 
 func TestFormatUnequalValues(t *testing.T) {
+	t.Parallel()
+
 	expected, actual := formatUnequalValues("foo", "bar")
 	Equal(t, `"foo"`, expected, "value should not include type")
 	Equal(t, `"bar"`, actual, "value should not include type")
@@ -816,6 +847,8 @@ func TestFormatUnequalValues(t *testing.T) {
 }
 
 func TestNotNil(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !NotNil(mockT, new(AssertionTesterConformingObject)) {
@@ -830,6 +863,8 @@ func TestNotNil(t *testing.T) {
 }
 
 func TestNil(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Nil(mockT, nil) {
@@ -844,6 +879,8 @@ func TestNil(t *testing.T) {
 }
 
 func TestTrue(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !True(mockT, true) {
@@ -855,6 +892,8 @@ func TestTrue(t *testing.T) {
 }
 
 func TestFalse(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !False(mockT, false) {
@@ -866,6 +905,7 @@ func TestFalse(t *testing.T) {
 }
 
 func TestExactly(t *testing.T) {
+	t.Parallel()
 	mockT := new(testing.T)
 
 	a := float32(1)
@@ -896,6 +936,7 @@ func TestExactly(t *testing.T) {
 }
 
 func TestNotEqual(t *testing.T) {
+	t.Parallel()
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -935,6 +976,8 @@ func TestNotEqual(t *testing.T) {
 }
 
 func TestNotEqualValues(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -978,6 +1021,8 @@ func TestNotEqualValues(t *testing.T) {
 }
 
 func TestContainsNotContains(t *testing.T) {
+	t.Parallel()
+
 	type A struct {
 		Name, Value string
 	}
@@ -1041,6 +1086,8 @@ func TestContainsNotContains(t *testing.T) {
 }
 
 func TestContainsNotContainsFailMessage(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(mockTestingT)
 
 	type nonContainer struct {
@@ -1097,6 +1144,8 @@ func TestContainsNotContainsFailMessage(t *testing.T) {
 }
 
 func TestContainsNotContainsOnNilValue(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(mockTestingT)
 
 	Contains(mockT, nil, "key")
@@ -1113,6 +1162,8 @@ func TestContainsNotContainsOnNilValue(t *testing.T) {
 }
 
 func TestSubsetNotSubset(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		list    interface{}
 		subset  interface{}
@@ -1198,6 +1249,8 @@ func TestSubsetNotSubset(t *testing.T) {
 }
 
 func TestNotSubsetNil(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	NotSubset(mockT, []string{"foo"}, nil)
 	if !mockT.Failed() {
@@ -1206,6 +1259,8 @@ func TestNotSubsetNil(t *testing.T) {
 }
 
 func Test_containsElement(t *testing.T) {
+	t.Parallel()
+
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
 	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
@@ -1256,6 +1311,8 @@ func Test_containsElement(t *testing.T) {
 }
 
 func TestElementsMatch(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -1297,6 +1354,8 @@ func TestElementsMatch(t *testing.T) {
 }
 
 func TestDiffLists(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		listA  interface{}
@@ -1381,6 +1440,8 @@ func TestDiffLists(t *testing.T) {
 }
 
 func TestNotElementsMatch(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -1427,6 +1488,8 @@ func TestNotElementsMatch(t *testing.T) {
 }
 
 func TestCondition(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Condition(mockT, func() bool { return true }, "Truth") {
@@ -1439,6 +1502,8 @@ func TestCondition(t *testing.T) {
 }
 
 func TestDidPanic(t *testing.T) {
+	t.Parallel()
+
 	const panicMsg = "Panic!"
 
 	if funcDidPanic, msg, _ := didPanic(func() {
@@ -1460,6 +1525,8 @@ func TestDidPanic(t *testing.T) {
 }
 
 func TestPanics(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !Panics(mockT, func() {
@@ -1475,6 +1542,8 @@ func TestPanics(t *testing.T) {
 }
 
 func TestPanicsWithValue(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !PanicsWithValue(mockT, "Panic!", func() {
@@ -1502,6 +1571,8 @@ func TestPanicsWithValue(t *testing.T) {
 }
 
 func TestPanicsWithError(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !PanicsWithError(mockT, "panic", func() {
@@ -1529,6 +1600,8 @@ func TestPanicsWithError(t *testing.T) {
 }
 
 func TestNotPanics(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	if !NotPanics(mockT, func() {
@@ -1544,6 +1617,8 @@ func TestNotPanics(t *testing.T) {
 }
 
 func TestNoError(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1574,6 +1649,8 @@ type customError struct{}
 func (*customError) Error() string { return "fail" }
 
 func TestError(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1603,6 +1680,8 @@ func TestError(t *testing.T) {
 }
 
 func TestEqualError(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1619,6 +1698,8 @@ func TestEqualError(t *testing.T) {
 }
 
 func TestErrorContains(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1637,6 +1718,8 @@ func TestErrorContains(t *testing.T) {
 }
 
 func Test_isEmpty(t *testing.T) {
+	t.Parallel()
+
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
 
@@ -1663,6 +1746,8 @@ func Test_isEmpty(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
@@ -1707,6 +1792,8 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestNotEmpty(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
@@ -1729,6 +1816,8 @@ func TestNotEmpty(t *testing.T) {
 }
 
 func Test_getLen(t *testing.T) {
+	t.Parallel()
+
 	falseCases := []interface{}{
 		nil,
 		0,
@@ -1774,6 +1863,8 @@ func Test_getLen(t *testing.T) {
 }
 
 func TestLen(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	False(t, Len(mockT, nil, 0), "nil does not have length")
@@ -1820,6 +1911,8 @@ func TestLen(t *testing.T) {
 }
 
 func TestWithinDuration(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	a := time.Now()
 	b := a.Add(10 * time.Second)
@@ -1838,6 +1931,8 @@ func TestWithinDuration(t *testing.T) {
 }
 
 func TestWithinRange(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	n := time.Now()
 	s := n.Add(-time.Second)
@@ -1856,6 +1951,8 @@ func TestWithinRange(t *testing.T) {
 }
 
 func TestInDelta(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	True(t, InDelta(mockT, 1.001, 1, 0.01), "|1.001 - 1| <= 0.01")
@@ -1894,6 +1991,8 @@ func TestInDelta(t *testing.T) {
 }
 
 func TestInDeltaSlice(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	True(t, InDeltaSlice(mockT,
@@ -1915,6 +2014,8 @@ func TestInDeltaSlice(t *testing.T) {
 }
 
 func TestInDeltaMapValues(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	for _, tc := range []struct {
@@ -1993,6 +2094,8 @@ func TestInDeltaMapValues(t *testing.T) {
 }
 
 func TestInEpsilon(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -2047,6 +2150,8 @@ func TestInEpsilon(t *testing.T) {
 }
 
 func TestInEpsilonSlice(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	True(t, InEpsilonSlice(mockT,
@@ -2063,6 +2168,8 @@ func TestInEpsilonSlice(t *testing.T) {
 }
 
 func TestRegexp(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -2116,12 +2223,16 @@ func testAutogeneratedFunction() {
 }
 
 func TestCallerInfoWithAutogeneratedFunctions(t *testing.T) {
+	t.Parallel()
+
 	NotPanics(t, func() {
 		testAutogeneratedFunction()
 	})
 }
 
 func TestZero(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	for _, test := range zeros {
@@ -2134,6 +2245,8 @@ func TestZero(t *testing.T) {
 }
 
 func TestNotZero(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	for _, test := range zeros {
@@ -2146,6 +2259,8 @@ func TestNotZero(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
+	// FIXME t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, FileExists(mockT, "assertions.go"))
 
@@ -2180,6 +2295,8 @@ func TestFileExists(t *testing.T) {
 }
 
 func TestNoFileExists(t *testing.T) {
+	// FIXME t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, NoFileExists(mockT, "assertions.go"))
 
@@ -2231,6 +2348,8 @@ func cleanUpTempFiles(paths []string) []error {
 }
 
 func TestDirExists(t *testing.T) {
+	// FIXME t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, DirExists(mockT, "assertions.go"))
 
@@ -2265,6 +2384,8 @@ func TestDirExists(t *testing.T) {
 }
 
 func TestNoDirExists(t *testing.T) {
+	// FIXME t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, NoDirExists(mockT, "assertions.go"))
 
@@ -2299,67 +2420,93 @@ func TestNoDirExists(t *testing.T) {
 }
 
 func TestJSONEq_EqualSONString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))
 }
 
 func TestJSONEq_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
 }
 
 func TestJSONEq_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, JSONEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
 		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}"))
 }
 
 func TestJSONEq_Array(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`))
 }
 
 func TestJSONEq_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`))
 }
 
 func TestJSONEq_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
 }
 
 func TestJSONEq_ActualIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `{"foo": "bar"}`, "Not JSON"))
 }
 
 func TestJSONEq_ExpectedIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, JSONEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`))
 }
 
 func TestJSONEq_ExpectedAndActualNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, JSONEq(mockT, "Not JSON", "Not JSON"))
 }
 
 func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
 }
 
 func TestYAMLEq_EqualYAMLString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, YAMLEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))
 }
 
 func TestYAMLEq_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, YAMLEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
 }
 
 func TestYAMLEq_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	expected := `
 numeric: 1.5
@@ -2390,36 +2537,50 @@ array:
 }
 
 func TestYAMLEq_Array(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`))
 }
 
 func TestYAMLEq_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`))
 }
 
 func TestYAMLEq_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, YAMLEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
 }
 
 func TestYAMLEq_ActualIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, YAMLEq(mockT, `{"foo": "bar"}`, "Simple String"))
 }
 
 func TestYAMLEq_ExpectedIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, YAMLEq(mockT, "Simple String", `{"foo": "bar", "hello": "world"}`))
 }
 
 func TestYAMLEq_ExpectedAndActualSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	True(t, YAMLEq(mockT, "Simple String", "Simple String"))
 }
 
 func TestYAMLEq_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 	False(t, YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
 }
@@ -2434,6 +2595,8 @@ func (d *diffTestingStruct) String() string {
 }
 
 func TestDiff(t *testing.T) {
+	t.Parallel()
+
 	expected := `
 
 Diff:
@@ -2568,6 +2731,8 @@ Diff:
 }
 
 func TestTimeEqualityErrorFormatting(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(mockTestingT)
 
 	Equal(mockT, time.Second*2, time.Millisecond)
@@ -2577,6 +2742,8 @@ func TestTimeEqualityErrorFormatting(t *testing.T) {
 }
 
 func TestDiffEmptyCases(t *testing.T) {
+	t.Parallel()
+
 	Equal(t, "", diff(nil, nil))
 	Equal(t, "", diff(struct{ foo string }{}, nil))
 	Equal(t, "", diff(nil, struct{ foo string }{}))
@@ -2638,6 +2805,8 @@ func (m *mockTestingT) Failed() bool {
 }
 
 func TestFailNowWithPlainTestingT(t *testing.T) {
+	t.Parallel()
+
 	mockT := &mockTestingT{}
 
 	Panics(t, func() {
@@ -2652,6 +2821,8 @@ func (m *mockFailNowTestingT) Errorf(format string, args ...interface{}) {}
 func (m *mockFailNowTestingT) FailNow() {}
 
 func TestFailNowWithFullTestingT(t *testing.T) {
+	t.Parallel()
+
 	mockT := &mockFailNowTestingT{}
 
 	NotPanics(t, func() {
@@ -2660,6 +2831,8 @@ func TestFailNowWithFullTestingT(t *testing.T) {
 }
 
 func TestBytesEqual(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		a, b []byte
 	}{
@@ -2725,6 +2898,8 @@ func ExampleComparisonAssertionFunc() {
 }
 
 func TestComparisonAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	type iface interface {
 		Name() string
 	}
@@ -2786,6 +2961,8 @@ func ExampleValueAssertionFunc() {
 }
 
 func TestValueAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		value     interface{}
@@ -2832,6 +3009,8 @@ func ExampleBoolAssertionFunc() {
 }
 
 func TestBoolAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		value     bool
@@ -2875,6 +3054,8 @@ func ExampleErrorAssertionFunc() {
 }
 
 func TestErrorAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		err       error
@@ -2911,6 +3092,8 @@ func ExamplePanicAssertionFunc() {
 }
 
 func TestPanicAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		panicFn   PanicTestFunc
@@ -2928,6 +3111,8 @@ func TestPanicAssertionFunc(t *testing.T) {
 }
 
 func TestEventuallyFalse(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	condition := func() bool {
@@ -2938,6 +3123,8 @@ func TestEventuallyFalse(t *testing.T) {
 }
 
 func TestEventuallyTrue(t *testing.T) {
+	t.Parallel()
+
 	state := 0
 	condition := func() bool {
 		defer func() {
@@ -2961,6 +3148,8 @@ func (t *errorsCapturingT) Errorf(format string, args ...interface{}) {
 func (t *errorsCapturingT) Helper() {}
 
 func TestEventuallyWithTFalse(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(errorsCapturingT)
 
 	condition := func(collect *CollectT) {
@@ -2972,6 +3161,8 @@ func TestEventuallyWithTFalse(t *testing.T) {
 }
 
 func TestEventuallyWithTTrue(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(errorsCapturingT)
 
 	counter := 0
@@ -2986,6 +3177,8 @@ func TestEventuallyWithTTrue(t *testing.T) {
 }
 
 func TestEventuallyWithT_ConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(errorsCapturingT)
 
 	condition := func(collect *CollectT) {
@@ -2998,6 +3191,8 @@ func TestEventuallyWithT_ConcurrencySafe(t *testing.T) {
 }
 
 func TestEventuallyWithT_ReturnsTheLatestFinishedConditionErrors(t *testing.T) {
+	t.Parallel()
+
 	// We'll use a channel to control whether a condition should sleep or not.
 	mustSleep := make(chan bool, 2)
 	mustSleep <- false
@@ -3021,6 +3216,8 @@ func TestEventuallyWithT_ReturnsTheLatestFinishedConditionErrors(t *testing.T) {
 }
 
 func TestEventuallyWithTFailNow(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(CollectT)
 
 	condition := func(collect *CollectT) {
@@ -3034,6 +3231,8 @@ func TestEventuallyWithTFailNow(t *testing.T) {
 // Check that a long running condition doesn't block Eventually.
 // See issue 805 (and its long tail of following issues)
 func TestEventuallyTimeout(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	NotPanics(t, func() {
@@ -3055,6 +3254,8 @@ func TestEventuallyTimeout(t *testing.T) {
 }
 
 func TestEventuallySucceedQuickly(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	condition := func() bool { return true }
@@ -3065,6 +3266,8 @@ func TestEventuallySucceedQuickly(t *testing.T) {
 }
 
 func TestEventuallyWithTSucceedQuickly(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	condition := func(t *CollectT) {}
@@ -3075,6 +3278,8 @@ func TestEventuallyWithTSucceedQuickly(t *testing.T) {
 }
 
 func TestNeverFalse(t *testing.T) {
+	t.Parallel()
+
 	condition := func() bool {
 		return false
 	}
@@ -3084,6 +3289,8 @@ func TestNeverFalse(t *testing.T) {
 
 // TestNeverTrue checks Never with a condition that returns true on second call.
 func TestNeverTrue(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	// A list of values returned by condition.
@@ -3102,6 +3309,8 @@ func TestNeverTrue(t *testing.T) {
 }
 
 func TestNeverFailQuickly(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(testing.T)
 
 	// By making the tick longer than the total duration, we expect that this test would fail if
@@ -3111,6 +3320,8 @@ func TestNeverFailQuickly(t *testing.T) {
 }
 
 func Test_validateEqualArgs(t *testing.T) {
+	t.Parallel()
+
 	if validateEqualArgs(func() {}, func() {}) == nil {
 		t.Error("non-nil functions should error")
 	}
@@ -3125,6 +3336,8 @@ func Test_validateEqualArgs(t *testing.T) {
 }
 
 func Test_truncatingFormat(t *testing.T) {
+	t.Parallel()
+
 	original := strings.Repeat("a", bufio.MaxScanTokenSize-102)
 	result := truncatingFormat(original)
 	Equal(t, fmt.Sprintf("%#v", original), result, "string should not be truncated")
@@ -3218,6 +3431,8 @@ func (ctt *captureTestingT) checkResultAndErrMsg(t *testing.T, expectedRes, res 
 }
 
 func TestErrorIs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		err          error
 		target       error
@@ -3285,6 +3500,8 @@ func TestErrorIs(t *testing.T) {
 }
 
 func TestNotErrorIs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		err          error
 		target       error
@@ -3351,6 +3568,8 @@ func TestNotErrorIs(t *testing.T) {
 }
 
 func TestErrorAs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		err          error
 		result       bool
@@ -3397,6 +3616,8 @@ func TestErrorAs(t *testing.T) {
 }
 
 func TestNotErrorAs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		err          error
 		result       bool

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestImplementsWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
@@ -19,6 +21,8 @@ func TestImplementsWrapper(t *testing.T) {
 }
 
 func TestIsTypeWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.IsType(new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
@@ -31,6 +35,8 @@ func TestIsTypeWrapper(t *testing.T) {
 }
 
 func TestEqualWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.Equal("Hello World", "Hello World") {
@@ -51,6 +57,8 @@ func TestEqualWrapper(t *testing.T) {
 }
 
 func TestEqualValuesWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.EqualValues(uint32(10), int32(10)) {
@@ -59,6 +67,8 @@ func TestEqualValuesWrapper(t *testing.T) {
 }
 
 func TestNotNilWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.NotNil(new(AssertionTesterConformingObject)) {
@@ -71,6 +81,8 @@ func TestNotNilWrapper(t *testing.T) {
 }
 
 func TestNilWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.Nil(nil) {
@@ -83,6 +95,8 @@ func TestNilWrapper(t *testing.T) {
 }
 
 func TestTrueWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.True(true) {
@@ -95,6 +109,8 @@ func TestTrueWrapper(t *testing.T) {
 }
 
 func TestFalseWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	if !assert.False(false) {
@@ -107,6 +123,8 @@ func TestFalseWrapper(t *testing.T) {
 }
 
 func TestExactlyWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	a := float32(1)
@@ -134,6 +152,7 @@ func TestExactlyWrapper(t *testing.T) {
 }
 
 func TestNotEqualWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 
@@ -155,6 +174,7 @@ func TestNotEqualWrapper(t *testing.T) {
 }
 
 func TestNotEqualValuesWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 
@@ -179,6 +199,7 @@ func TestNotEqualValuesWrapper(t *testing.T) {
 }
 
 func TestContainsWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 	list := []string{"Foo", "Bar"}
@@ -200,6 +221,7 @@ func TestContainsWrapper(t *testing.T) {
 }
 
 func TestNotContainsWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 	list := []string{"Foo", "Bar"}
@@ -221,6 +243,7 @@ func TestNotContainsWrapper(t *testing.T) {
 }
 
 func TestConditionWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 
@@ -235,6 +258,7 @@ func TestConditionWrapper(t *testing.T) {
 }
 
 func TestDidPanicWrapper(t *testing.T) {
+	t.Parallel()
 
 	if funcDidPanic, _, _ := didPanic(func() {
 		panic("Panic!")
@@ -250,6 +274,7 @@ func TestDidPanicWrapper(t *testing.T) {
 }
 
 func TestPanicsWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 
@@ -267,6 +292,7 @@ func TestPanicsWrapper(t *testing.T) {
 }
 
 func TestNotPanicsWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 
@@ -284,6 +310,8 @@ func TestNotPanicsWrapper(t *testing.T) {
 }
 
 func TestNoErrorWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -300,6 +328,8 @@ func TestNoErrorWrapper(t *testing.T) {
 }
 
 func TestErrorWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -316,6 +346,8 @@ func TestErrorWrapper(t *testing.T) {
 }
 
 func TestErrorContainsWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -335,6 +367,8 @@ func TestErrorContainsWrapper(t *testing.T) {
 }
 
 func TestEqualErrorWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -352,6 +386,8 @@ func TestEqualErrorWrapper(t *testing.T) {
 }
 
 func TestEmptyWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -370,6 +406,8 @@ func TestEmptyWrapper(t *testing.T) {
 }
 
 func TestNotEmptyWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -388,6 +426,8 @@ func TestNotEmptyWrapper(t *testing.T) {
 }
 
 func TestLenWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -428,6 +468,8 @@ func TestLenWrapper(t *testing.T) {
 }
 
 func TestWithinDurationWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 	a := time.Now()
@@ -447,6 +489,8 @@ func TestWithinDurationWrapper(t *testing.T) {
 }
 
 func TestInDeltaWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	True(t, assert.InDelta(1.001, 1, 0.01), "|1.001 - 1| <= 0.01")
@@ -481,6 +525,8 @@ func TestInDeltaWrapper(t *testing.T) {
 }
 
 func TestInEpsilonWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 
 	cases := []struct {
@@ -519,6 +565,7 @@ func TestInEpsilonWrapper(t *testing.T) {
 }
 
 func TestRegexpWrapper(t *testing.T) {
+	t.Parallel()
 
 	assert := New(new(testing.T))
 
@@ -554,6 +601,8 @@ func TestRegexpWrapper(t *testing.T) {
 }
 
 func TestZeroWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -567,6 +616,8 @@ func TestZeroWrapper(t *testing.T) {
 }
 
 func TestNotZeroWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -580,6 +631,8 @@ func TestNotZeroWrapper(t *testing.T) {
 }
 
 func TestJSONEqWrapper_EqualSONString(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`) {
 		t.Error("JSONEq should return true")
@@ -588,6 +641,8 @@ func TestJSONEqWrapper_EqualSONString(t *testing.T) {
 }
 
 func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return true")
@@ -596,6 +651,8 @@ func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
 }
 
 func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.JSONEq("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
 		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}") {
@@ -604,6 +661,8 @@ func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
 }
 
 func TestJSONEqWrapper_Array(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`) {
 		t.Error("JSONEq should return true")
@@ -612,6 +671,8 @@ func TestJSONEqWrapper_Array(t *testing.T) {
 }
 
 func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`) {
 		t.Error("JSONEq should return false")
@@ -619,6 +680,8 @@ func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
 }
 
 func TestJSONEqWrapper_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.JSONEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return false")
@@ -626,6 +689,8 @@ func TestJSONEqWrapper_HashesNotEquivalent(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ActualIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.JSONEq(`{"foo": "bar"}`, "Not JSON") {
 		t.Error("JSONEq should return false")
@@ -633,6 +698,8 @@ func TestJSONEqWrapper_ActualIsNotJSON(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ExpectedIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.JSONEq("Not JSON", `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return false")
@@ -640,6 +707,8 @@ func TestJSONEqWrapper_ExpectedIsNotJSON(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ExpectedAndActualNotJSON(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.JSONEq("Not JSON", "Not JSON") {
 		t.Error("JSONEq should return false")
@@ -647,6 +716,8 @@ func TestJSONEqWrapper_ExpectedAndActualNotJSON(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`) {
 		t.Error("JSONEq should return false")
@@ -654,6 +725,8 @@ func TestJSONEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_EqualYAMLString(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.YAMLEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`) {
 		t.Error("YAMLEq should return true")
@@ -662,6 +735,8 @@ func TestYAMLEqWrapper_EqualYAMLString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.YAMLEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("YAMLEq should return true")
@@ -670,6 +745,8 @@ func TestYAMLEqWrapper_EquivalentButNotEqual(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	expected := `
 numeric: 1.5
@@ -702,6 +779,8 @@ array:
 }
 
 func TestYAMLEqWrapper_Array(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.YAMLEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`) {
 		t.Error("YAMLEq should return true")
@@ -710,6 +789,8 @@ func TestYAMLEqWrapper_Array(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.YAMLEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`) {
 		t.Error("YAMLEq should return false")
@@ -717,6 +798,8 @@ func TestYAMLEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.YAMLEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("YAMLEq should return false")
@@ -724,6 +807,8 @@ func TestYAMLEqWrapper_HashesNotEquivalent(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ActualIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.YAMLEq(`{"foo": "bar"}`, "Simple String") {
 		t.Error("YAMLEq should return false")
@@ -731,6 +816,8 @@ func TestYAMLEqWrapper_ActualIsSimpleString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ExpectedIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.YAMLEq("Simple String", `{"foo": "bar", "hello": "world"}`) {
 		t.Error("YAMLEq should return false")
@@ -738,6 +825,8 @@ func TestYAMLEqWrapper_ExpectedIsSimpleString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ExpectedAndActualSimpleString(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if !assert.YAMLEq("Simple String", "Simple String") {
 		t.Error("YAMLEq should return true")
@@ -745,6 +834,8 @@ func TestYAMLEqWrapper_ExpectedAndActualSimpleString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	assert := New(new(testing.T))
 	if assert.YAMLEq(`["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`) {
 		t.Error("YAMLEq should return false")

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -31,6 +31,8 @@ func httpStatusCode(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestHTTPSuccess(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 
 	mockT1 := new(testing.T)
@@ -59,6 +61,8 @@ func TestHTTPSuccess(t *testing.T) {
 }
 
 func TestHTTPRedirect(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 
 	mockT1 := new(mockTestingT)
@@ -83,6 +87,8 @@ func TestHTTPRedirect(t *testing.T) {
 }
 
 func TestHTTPError(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 
 	mockT1 := new(testing.T)
@@ -107,6 +113,8 @@ func TestHTTPError(t *testing.T) {
 }
 
 func TestHTTPStatusCode(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 
 	mockT1 := new(testing.T)
@@ -131,6 +139,8 @@ func TestHTTPStatusCode(t *testing.T) {
 }
 
 func TestHTTPStatusesWrapper(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
@@ -153,6 +163,8 @@ func httpHelloName(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestHTTPRequestWithNoParams(t *testing.T) {
+	t.Parallel()
+
 	var got *http.Request
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		got = r
@@ -166,6 +178,8 @@ func TestHTTPRequestWithNoParams(t *testing.T) {
 }
 
 func TestHTTPRequestWithParams(t *testing.T) {
+	t.Parallel()
+
 	var got *http.Request
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		got = r
@@ -182,6 +196,8 @@ func TestHTTPRequestWithParams(t *testing.T) {
 }
 
 func TestHttpBody(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockT := new(mockTestingT)
 
@@ -201,6 +217,8 @@ func TestHttpBody(t *testing.T) {
 }
 
 func TestHttpBodyWrappers(t *testing.T) {
+	t.Parallel()
+
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -163,6 +163,7 @@ func (m *MockTestingT) FailNow() {
 */
 
 func Test_Mock_TestData(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -174,6 +175,7 @@ func Test_Mock_TestData(t *testing.T) {
 }
 
 func Test_Mock_On(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -184,6 +186,8 @@ func Test_Mock_On(t *testing.T) {
 }
 
 func Test_Mock_Chained_On(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -215,6 +219,7 @@ func Test_Mock_Chained_On(t *testing.T) {
 }
 
 func Test_Mock_On_WithArgs(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -227,6 +232,7 @@ func Test_Mock_On_WithArgs(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncArg(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -248,6 +254,8 @@ func Test_Mock_On_WithFuncArg(t *testing.T) {
 }
 
 func Test_Mock_On_WithIntArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod",
@@ -271,6 +279,8 @@ func Test_Mock_On_WithIntArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithArgMatcherThatPanics(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod2", MatchedBy(func(_ interface{}) bool {
@@ -297,6 +307,8 @@ func Test_Mock_On_WithArgMatcherThatPanics(t *testing.T) {
 }
 
 func TestMock_WithTest(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockedService TestExampleImplementation
 		mockedTest    MockTestingT
@@ -325,6 +337,8 @@ func TestMock_WithTest(t *testing.T) {
 }
 
 func Test_Mock_On_WithPtrArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod3",
@@ -345,6 +359,8 @@ func Test_Mock_On_WithPtrArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	fixture1, fixture2 := errors.New("fixture1"), errors.New("fixture2")
@@ -369,6 +385,8 @@ func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithInterfaceArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod4",
@@ -379,6 +397,8 @@ func Test_Mock_On_WithInterfaceArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithChannelArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod5",
@@ -389,6 +409,8 @@ func Test_Mock_On_WithChannelArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithMapArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod6",
@@ -399,6 +421,8 @@ func Test_Mock_On_WithMapArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithSliceArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod7",
@@ -409,6 +433,7 @@ func Test_Mock_On_WithSliceArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFunc(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -431,6 +456,7 @@ func Test_Mock_On_WithVariadicFunc(t *testing.T) {
 }
 
 func Test_Mock_On_WithMixedVariadicFunc(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -454,6 +480,7 @@ func Test_Mock_On_WithMixedVariadicFunc(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -475,6 +502,7 @@ func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -498,6 +526,8 @@ func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncPanics(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -507,6 +537,7 @@ func Test_Mock_On_WithFuncPanics(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -526,6 +557,8 @@ func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
 }
 
 func Test_Mock_Unset(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -554,6 +587,8 @@ func Test_Mock_Unset(t *testing.T) {
 // Since every time you call On it creates a new object
 // the last time you call Unset it will only unset the last call
 func Test_Mock_Chained_UnsetOnlyUnsetsLastCall(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -588,6 +623,8 @@ func Test_Mock_Chained_UnsetOnlyUnsetsLastCall(t *testing.T) {
 }
 
 func Test_Mock_UnsetIfAlreadyUnsetFails(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -607,6 +644,8 @@ func Test_Mock_UnsetIfAlreadyUnsetFails(t *testing.T) {
 }
 
 func Test_Mock_UnsetByOnMethodSpec(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -628,6 +667,8 @@ func Test_Mock_UnsetByOnMethodSpec(t *testing.T) {
 }
 
 func Test_Mock_UnsetByOnMethodSpecAmongOthers(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -670,6 +711,8 @@ func Test_Mock_UnsetByOnMethodSpecAmongOthers(t *testing.T) {
 }
 
 func Test_Mock_Unset_WithFuncPanics(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 	mock1 := mockedService.On("TheExampleMethod", 1)
@@ -681,6 +724,7 @@ func Test_Mock_Unset_WithFuncPanics(t *testing.T) {
 }
 
 func Test_Mock_Return(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -705,6 +749,7 @@ func Test_Mock_Return(t *testing.T) {
 }
 
 func Test_Mock_Panic(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -728,6 +773,7 @@ func Test_Mock_Panic(t *testing.T) {
 }
 
 func Test_Mock_Return_WaitUntil(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -755,6 +801,7 @@ func Test_Mock_Return_WaitUntil(t *testing.T) {
 }
 
 func Test_Mock_Return_After(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -781,6 +828,7 @@ func Test_Mock_Return_After(t *testing.T) {
 }
 
 func Test_Mock_Return_Run(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -813,6 +861,8 @@ func Test_Mock_Return_Run(t *testing.T) {
 }
 
 func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 	f := func(args Arguments) {
@@ -838,6 +888,7 @@ func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_Once(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -862,6 +913,7 @@ func Test_Mock_Return_Once(t *testing.T) {
 }
 
 func Test_Mock_Return_Twice(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -887,6 +939,7 @@ func Test_Mock_Return_Twice(t *testing.T) {
 }
 
 func Test_Mock_Return_Times(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -912,6 +965,7 @@ func Test_Mock_Return_Times(t *testing.T) {
 }
 
 func Test_Mock_Return_Nothing(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -932,6 +986,8 @@ func Test_Mock_Return_Nothing(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_In_Order(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	b := mockedService.
@@ -952,6 +1008,8 @@ func Test_Mock_Return_NotBefore_In_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_InOrder_Uses_NotBefore(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	InOrder(
@@ -972,6 +1030,8 @@ func Test_Mock_Return_InOrder_Uses_NotBefore(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	b := mockedService.
@@ -1002,6 +1062,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_InOrder_Uses_NotBefore_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	InOrder(
@@ -1031,6 +1093,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_NotBefore_Not_Enough_Times(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	b := mockedService.
@@ -1064,6 +1128,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_NotBefore_Different_Mock_In_Order(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockedService1 = new(TestExampleImplementation)
 		mockedService2 = new(TestExampleImplementation)
@@ -1087,6 +1153,8 @@ func Test_Mock_Return_NotBefore_Different_Mock_In_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_Different_Mock_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockedService1 = new(TestExampleImplementation)
 		mockedService2 = new(TestExampleImplementation)
@@ -1120,6 +1188,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_NotBefore_In_Order_With_Non_Dependant(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	a := mockedService.
@@ -1160,6 +1230,8 @@ func Test_Mock_Return_NotBefore_In_Order_With_Non_Dependant(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_Orphan_Call(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	require.PanicsWithValue(t, "not before calls must be created with Mock.On()", func() {
@@ -1171,6 +1243,7 @@ func Test_Mock_Return_NotBefore_Orphan_Call(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall(t *testing.T) {
+	t.Parallel()
 
 	m := new(Mock)
 	m.On("One", 1).Return("one")
@@ -1190,6 +1263,7 @@ func Test_Mock_findExpectedCall(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
+	t.Parallel()
 
 	m := new(Mock)
 	m.On("One", 1).Return("one")
@@ -1203,6 +1277,7 @@ func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	m := new(Mock)
 	m.On("One", 1).Return("one")
@@ -1233,6 +1308,7 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 }
 
 func Test_callString(t *testing.T) {
+	t.Parallel()
 
 	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
 	assert.Equal(t, `Method(<nil>)`, callString("Method", []interface{}{nil}, false))
@@ -1240,6 +1316,7 @@ func Test_callString(t *testing.T) {
 }
 
 func Test_Mock_Called(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1267,6 +1344,7 @@ func asyncCall(m *Mock, ch chan Arguments) {
 }
 
 func Test_Mock_Called_blocks(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1300,6 +1378,7 @@ func Test_Mock_Called_blocks(t *testing.T) {
 }
 
 func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1341,6 +1420,7 @@ func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 }
 
 func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1357,6 +1437,7 @@ func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 }
 
 func Test_Mock_Called_Unexpected(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1368,6 +1449,7 @@ func Test_Mock_Called_Unexpected(t *testing.T) {
 }
 
 func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
+	t.Parallel()
 
 	var mockedService1 = new(TestExampleImplementation)
 	var mockedService2 = new(TestExampleImplementation)
@@ -1388,6 +1470,7 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 }
 
 func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
+	t.Parallel()
 
 	var mockedService1 = new(TestExampleImplementation)
 	var mockedService2 = new(TestExampleImplementation)
@@ -1407,6 +1490,7 @@ func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1424,6 +1508,7 @@ func Test_Mock_AssertExpectations(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_Placeholder_NoArgs(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1442,6 +1527,7 @@ func Test_Mock_AssertExpectations_Placeholder_NoArgs(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_Placeholder(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1465,6 +1551,7 @@ func Test_Mock_AssertExpectations_Placeholder(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_With_Pointers(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1486,6 +1573,7 @@ func Test_Mock_AssertExpectations_With_Pointers(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1503,6 +1591,7 @@ func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1520,6 +1609,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1537,6 +1627,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1554,6 +1645,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) 
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Func(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1568,6 +1660,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Func(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Arg(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1582,6 +1675,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Arg(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1603,6 +1697,7 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1613,6 +1708,7 @@ func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
 }
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1632,6 +1728,7 @@ func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 }
 
 func Test_Mock_AssertNumberOfCalls(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1646,6 +1743,7 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1658,6 +1756,7 @@ func Test_Mock_AssertCalled(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1672,6 +1771,7 @@ func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1686,6 +1786,7 @@ func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1703,6 +1804,7 @@ func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 }
 
 func Test_Mock_AssertNotCalled(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1715,6 +1817,8 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 }
 
 func Test_Mock_IsMethodCallable(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	arg := []Call{{Repeatability: 1}, {Repeatability: 2}}
@@ -1734,6 +1838,8 @@ func Test_Mock_IsMethodCallable(t *testing.T) {
 }
 
 func TestIsArgsEqual(t *testing.T) {
+	t.Parallel()
+
 	var expected = Arguments{5, 3, 4, 6, 7, 2}
 
 	// Copy elements 1 to 5
@@ -1747,6 +1853,8 @@ func TestIsArgsEqual(t *testing.T) {
 }
 
 func Test_Mock_AssertOptional(t *testing.T) {
+	t.Parallel()
+
 	// Optional called
 	var ms1 = new(TestExampleImplementation)
 	ms1.On("TheExampleMethod", 1, 2, 3).Maybe().Return(4, nil)
@@ -1775,6 +1883,7 @@ func Test_Mock_AssertOptional(t *testing.T) {
 Arguments helper methods
 */
 func Test_Arguments_Get(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 
@@ -1785,6 +1894,7 @@ func Test_Arguments_Get(t *testing.T) {
 }
 
 func Test_Arguments_Is(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 
@@ -1794,6 +1904,7 @@ func Test_Arguments_Is(t *testing.T) {
 }
 
 func Test_Arguments_Diff(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"Hello World", 123, true})
 	var diff string
@@ -1807,6 +1918,7 @@ func Test_Arguments_Diff(t *testing.T) {
 }
 
 func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	var diff string
@@ -1819,6 +1931,7 @@ func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	var count int
@@ -1829,6 +1942,7 @@ func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", Anything, true})
 	var count int
@@ -1839,6 +1953,7 @@ func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", AnythingOfType("int"), true})
 	var count int
@@ -1849,6 +1964,7 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", AnythingOfType("string"), true})
 	var count int
@@ -1861,6 +1977,8 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
+	t.Parallel()
+
 	var args = Arguments([]interface{}{"string", IsType(0), true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", 123, true})
@@ -1869,6 +1987,8 @@ func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
+	t.Parallel()
+
 	var args = Arguments([]interface{}{"string", IsType(""), true})
 	var count int
 	var diff string
@@ -1879,6 +1999,8 @@ func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	matchFn := func(a int) bool {
 		return a == 123
 	}
@@ -1902,6 +2024,7 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 }
 
 func Test_Arguments_Assert(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 
@@ -1910,6 +2033,7 @@ func Test_Arguments_Assert(t *testing.T) {
 }
 
 func Test_Arguments_String_Representation(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, `string,int,bool`, args.String())
@@ -1917,6 +2041,7 @@ func Test_Arguments_String_Representation(t *testing.T) {
 }
 
 func Test_Arguments_String(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, "string", args.String(0))
@@ -1924,6 +2049,7 @@ func Test_Arguments_String(t *testing.T) {
 }
 
 func Test_Arguments_Error(t *testing.T) {
+	t.Parallel()
 
 	var err = errors.New("An Error")
 	var args = Arguments([]interface{}{"string", 123, true, err})
@@ -1932,6 +2058,7 @@ func Test_Arguments_Error(t *testing.T) {
 }
 
 func Test_Arguments_Error_Nil(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true, nil})
 	assert.Equal(t, nil, args.Error(3))
@@ -1939,6 +2066,7 @@ func Test_Arguments_Error_Nil(t *testing.T) {
 }
 
 func Test_Arguments_Int(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, 123, args.Int(1))
@@ -1946,6 +2074,7 @@ func Test_Arguments_Int(t *testing.T) {
 }
 
 func Test_Arguments_Bool(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
@@ -1953,6 +2082,7 @@ func Test_Arguments_Bool(t *testing.T) {
 }
 
 func Test_WaitUntil_Parallel(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -1979,6 +2109,8 @@ func Test_WaitUntil_Parallel(t *testing.T) {
 }
 
 func Test_MockMethodCalled(t *testing.T) {
+	t.Parallel()
+
 	m := new(Mock)
 	m.On("foo", "hello").Return("world")
 
@@ -1989,6 +2121,8 @@ func Test_MockMethodCalled(t *testing.T) {
 }
 
 func Test_MockMethodCalled_Panic(t *testing.T) {
+	t.Parallel()
+
 	m := new(Mock)
 	m.On("foo", "hello").Panic("world panics")
 
@@ -1998,6 +2132,8 @@ func Test_MockMethodCalled_Panic(t *testing.T) {
 
 // Test to validate fix for racy concurrent call access in MethodCalled()
 func Test_MockReturnAndCalledConcurrent(t *testing.T) {
+	t.Parallel()
+
 	iterations := 1000
 	m := &Mock{}
 	call := m.On("ConcurrencyTestMethod")
@@ -2048,6 +2184,8 @@ func (tc *tCustomLogger) Errorf(format string, args ...interface{}) {
 func (tc *tCustomLogger) FailNow() {}
 
 func TestLoggingAssertExpectations(t *testing.T) {
+	t.Parallel()
+
 	m := new(timer)
 	m.On("GetTime", 0).Return("")
 	tcl := &tCustomLogger{t, []string{}, []string{}}
@@ -2062,6 +2200,8 @@ func TestLoggingAssertExpectations(t *testing.T) {
 }
 
 func TestAfterTotalWaitTimeWhileExecution(t *testing.T) {
+	t.Parallel()
+
 	waitDuration := 1
 	total, waitMs := 5, time.Millisecond*time.Duration(waitDuration)
 	aTimer := new(timer)
@@ -2086,6 +2226,8 @@ func TestAfterTotalWaitTimeWhileExecution(t *testing.T) {
 }
 
 func TestArgumentMatcherToPrintMismatch(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(
@@ -2103,6 +2245,8 @@ func TestArgumentMatcherToPrintMismatch(t *testing.T) {
 }
 
 func TestArgumentMatcherToPrintMismatchWithReferenceType(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(
@@ -2120,6 +2264,8 @@ func TestArgumentMatcherToPrintMismatchWithReferenceType(t *testing.T) {
 }
 
 func TestClosestCallMismatchedArgumentInformationShowsTheClosest(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(unexpectedCallRegex(`TheExampleMethod(int,int,int)`, `0: 1\s+1: 1\s+2: 2`, `0: 1\s+1: 1\s+2: 1`, `Diff: 0: PASS:  \(int=1\) == \(int=1\)\s+1: PASS:  \(int=1\) == \(int=1\)\s+2: FAIL:  \(int=2\) != \(int=1\)`))
@@ -2135,6 +2281,8 @@ func TestClosestCallMismatchedArgumentInformationShowsTheClosest(t *testing.T) {
 }
 
 func TestClosestCallFavorsFirstMock(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			diffRegExp := `Difference found in argument 0:\s+--- Expected\s+\+\+\+ Actual\s+@@ -2,4 \+2,4 @@\s+\(bool\) true,\s+- \(bool\) true,\s+- \(bool\) true\s+\+ \(bool\) false,\s+\+ \(bool\) false\s+}\s+Diff: 0: FAIL:  \(\[\]bool=\[(true\s?|false\s?){3}]\) != \(\[\]bool=\[(true\s?|false\s?){3}\]\)`
@@ -2151,6 +2299,8 @@ func TestClosestCallFavorsFirstMock(t *testing.T) {
 }
 
 func TestClosestCallUsesRepeatabilityToFindClosest(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			diffRegExp := `Difference found in argument 0:\s+--- Expected\s+\+\+\+ Actual\s+@@ -1,4 \+1,4 @@\s+\(\[\]bool\) \(len=3\) {\s+- \(bool\) false,\s+- \(bool\) false,\s+\+ \(bool\) true,\s+\+ \(bool\) true,\s+\(bool\) false\s+Diff: 0: FAIL:  \(\[\]bool=\[(true\s?|false\s?){3}]\) != \(\[\]bool=\[(true\s?|false\s?){3}\]\)`
@@ -2171,6 +2321,8 @@ func TestClosestCallUsesRepeatabilityToFindClosest(t *testing.T) {
 }
 
 func TestClosestCallMismatchedArgumentValueInformation(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(unexpectedCallRegex(`GetTime(int)`, "0: 1", "0: 999", `Diff: 0: FAIL:  \(int=1\) != \(int=999\)`))
@@ -2185,26 +2337,38 @@ func TestClosestCallMismatchedArgumentValueInformation(t *testing.T) {
 }
 
 func Test_isBetterMatchThanReturnsFalseIfCandidateCallIsNil(t *testing.T) {
+	t.Parallel()
+
 	assert.False(t, matchCandidate{}.isBetterMatchThan(matchCandidate{}))
 }
 
 func Test_isBetterMatchThanReturnsTrueIfOtherCandidateCallIsNil(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, matchCandidate{call: &Call{}}.isBetterMatchThan(matchCandidate{}))
 }
 
 func Test_isBetterMatchThanReturnsFalseIfDiffCountIsGreaterThanOther(t *testing.T) {
+	t.Parallel()
+
 	assert.False(t, matchCandidate{call: &Call{}, diffCount: 2}.isBetterMatchThan(matchCandidate{call: &Call{}, diffCount: 1}))
 }
 
 func Test_isBetterMatchThanReturnsTrueIfDiffCountIsLessThanOther(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, matchCandidate{call: &Call{}, diffCount: 1}.isBetterMatchThan(matchCandidate{call: &Call{}, diffCount: 2}))
 }
 
 func Test_isBetterMatchThanReturnsTrueIfRepeatabilityIsGreaterThanOther(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, matchCandidate{call: &Call{Repeatability: 1}, diffCount: 1}.isBetterMatchThan(matchCandidate{call: &Call{Repeatability: -1}, diffCount: 1}))
 }
 
 func Test_isBetterMatchThanReturnsFalseIfRepeatabilityIsLessThanOrEqualToOther(t *testing.T) {
+	t.Parallel()
+
 	assert.False(t, matchCandidate{call: &Call{Repeatability: 1}, diffCount: 1}.isBetterMatchThan(matchCandidate{call: &Call{Repeatability: 1}, diffCount: 1}))
 }
 
@@ -2220,6 +2384,8 @@ func ConcurrencyTestMethod(m *Mock) {
 }
 
 func TestConcurrentArgumentRead(t *testing.T) {
+	t.Parallel()
+
 	methodUnderTest := func(c caller, u user) {
 		go u.Use(c)
 		c.Call()

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -132,6 +132,9 @@ type MockTestingT struct {
 	logfCount, errorfCount, failNowCount int
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (MockTestingT) Helper() {}
+
 const mockTestingTFailNowCalled = "FailNow was called"
 
 func (m *MockTestingT) Logf(string, ...interface{}) {

--- a/require/forward_requirements_test.go
+++ b/require/forward_requirements_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestImplementsWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 
 	require.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject))
@@ -20,6 +22,8 @@ func TestImplementsWrapper(t *testing.T) {
 }
 
 func TestIsNotTypeWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.IsNotType(new(AssertionTesterNonConformingObject), new(AssertionTesterConformingObject))
 
@@ -32,6 +36,8 @@ func TestIsNotTypeWrapper(t *testing.T) {
 }
 
 func TestIsTypeWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.IsType(new(AssertionTesterConformingObject), new(AssertionTesterConformingObject))
 
@@ -44,6 +50,8 @@ func TestIsTypeWrapper(t *testing.T) {
 }
 
 func TestEqualWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Equal(1, 1)
 
@@ -56,6 +64,8 @@ func TestEqualWrapper(t *testing.T) {
 }
 
 func TestNotEqualWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NotEqual(1, 2)
 
@@ -68,6 +78,8 @@ func TestNotEqualWrapper(t *testing.T) {
 }
 
 func TestExactlyWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 
 	a := float32(1)
@@ -85,6 +97,8 @@ func TestExactlyWrapper(t *testing.T) {
 }
 
 func TestNotNilWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NotNil(t, new(AssertionTesterConformingObject))
 
@@ -97,6 +111,8 @@ func TestNotNilWrapper(t *testing.T) {
 }
 
 func TestNilWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Nil(nil)
 
@@ -109,6 +125,8 @@ func TestNilWrapper(t *testing.T) {
 }
 
 func TestTrueWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.True(true)
 
@@ -121,6 +139,8 @@ func TestTrueWrapper(t *testing.T) {
 }
 
 func TestFalseWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.False(false)
 
@@ -133,6 +153,8 @@ func TestFalseWrapper(t *testing.T) {
 }
 
 func TestContainsWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Contains("Hello World", "Hello")
 
@@ -145,6 +167,8 @@ func TestContainsWrapper(t *testing.T) {
 }
 
 func TestNotContainsWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NotContains("Hello World", "Hello!")
 
@@ -157,6 +181,8 @@ func TestNotContainsWrapper(t *testing.T) {
 }
 
 func TestPanicsWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Panics(func() {
 		panic("Panic!")
@@ -171,6 +197,8 @@ func TestPanicsWrapper(t *testing.T) {
 }
 
 func TestNotPanicsWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NotPanics(func() {})
 
@@ -185,6 +213,8 @@ func TestNotPanicsWrapper(t *testing.T) {
 }
 
 func TestNoErrorWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NoError(nil)
 
@@ -197,6 +227,8 @@ func TestNoErrorWrapper(t *testing.T) {
 }
 
 func TestErrorWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Error(errors.New("some error"))
 
@@ -209,6 +241,8 @@ func TestErrorWrapper(t *testing.T) {
 }
 
 func TestErrorContainsWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.ErrorContains(errors.New("some error: another error"), "some error")
 
@@ -221,6 +255,8 @@ func TestErrorContainsWrapper(t *testing.T) {
 }
 
 func TestEqualErrorWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.EqualError(errors.New("some error"), "some error")
 
@@ -233,6 +269,8 @@ func TestEqualErrorWrapper(t *testing.T) {
 }
 
 func TestEmptyWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Empty("")
 
@@ -245,6 +283,8 @@ func TestEmptyWrapper(t *testing.T) {
 }
 
 func TestNotEmptyWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NotEmpty("x")
 
@@ -257,6 +297,8 @@ func TestNotEmptyWrapper(t *testing.T) {
 }
 
 func TestWithinDurationWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	a := time.Now()
 	b := a.Add(10 * time.Second)
@@ -272,6 +314,8 @@ func TestWithinDurationWrapper(t *testing.T) {
 }
 
 func TestInDeltaWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.InDelta(1.001, 1, 0.01)
 
@@ -284,6 +328,8 @@ func TestInDeltaWrapper(t *testing.T) {
 }
 
 func TestZeroWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.Zero(0)
 
@@ -296,6 +342,8 @@ func TestZeroWrapper(t *testing.T) {
 }
 
 func TestNotZeroWrapper(t *testing.T) {
+	t.Parallel()
+
 	require := New(t)
 	require.NotZero(1)
 
@@ -308,6 +356,8 @@ func TestNotZeroWrapper(t *testing.T) {
 }
 
 func TestJSONEqWrapper_EqualSONString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -318,6 +368,8 @@ func TestJSONEqWrapper_EqualSONString(t *testing.T) {
 }
 
 func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -328,6 +380,8 @@ func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
 }
 
 func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -339,6 +393,8 @@ func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
 }
 
 func TestJSONEqWrapper_Array(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -349,6 +405,8 @@ func TestJSONEqWrapper_Array(t *testing.T) {
 }
 
 func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -359,6 +417,8 @@ func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
 }
 
 func TestJSONEqWrapper_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -369,6 +429,8 @@ func TestJSONEqWrapper_HashesNotEquivalent(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ActualIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -379,6 +441,8 @@ func TestJSONEqWrapper_ActualIsNotJSON(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ExpectedIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -389,6 +453,8 @@ func TestJSONEqWrapper_ExpectedIsNotJSON(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ExpectedAndActualNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -399,6 +465,8 @@ func TestJSONEqWrapper_ExpectedAndActualNotJSON(t *testing.T) {
 }
 
 func TestJSONEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -409,6 +477,8 @@ func TestJSONEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_EqualYAMLString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -419,6 +489,8 @@ func TestYAMLEqWrapper_EqualYAMLString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -429,6 +501,8 @@ func TestYAMLEqWrapper_EquivalentButNotEqual(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -465,6 +539,8 @@ array:
 }
 
 func TestYAMLEqWrapper_Array(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -475,6 +551,8 @@ func TestYAMLEqWrapper_Array(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -485,6 +563,8 @@ func TestYAMLEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -495,6 +575,8 @@ func TestYAMLEqWrapper_HashesNotEquivalent(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ActualIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -505,6 +587,8 @@ func TestYAMLEqWrapper_ActualIsSimpleString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ExpectedIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -515,6 +599,8 @@ func TestYAMLEqWrapper_ExpectedIsSimpleString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ExpectedAndActualSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -525,6 +611,8 @@ func TestYAMLEqWrapper_ExpectedAndActualSimpleString(t *testing.T) {
 }
 
 func TestYAMLEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -38,6 +38,7 @@ func (t *MockT) Errorf(format string, args ...interface{}) {
 }
 
 func TestImplements(t *testing.T) {
+	t.Parallel()
 
 	Implements(t, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject))
 
@@ -49,6 +50,7 @@ func TestImplements(t *testing.T) {
 }
 
 func TestIsType(t *testing.T) {
+	t.Parallel()
 
 	IsType(t, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject))
 
@@ -60,6 +62,7 @@ func TestIsType(t *testing.T) {
 }
 
 func TestEqual(t *testing.T) {
+	t.Parallel()
 
 	Equal(t, 1, 1)
 
@@ -72,6 +75,7 @@ func TestEqual(t *testing.T) {
 }
 
 func TestNotEqual(t *testing.T) {
+	t.Parallel()
 
 	NotEqual(t, 1, 2)
 	mockT := new(MockT)
@@ -82,6 +86,7 @@ func TestNotEqual(t *testing.T) {
 }
 
 func TestExactly(t *testing.T) {
+	t.Parallel()
 
 	a := float32(1)
 	b := float32(1)
@@ -97,6 +102,7 @@ func TestExactly(t *testing.T) {
 }
 
 func TestNotNil(t *testing.T) {
+	t.Parallel()
 
 	NotNil(t, new(AssertionTesterConformingObject))
 
@@ -108,6 +114,7 @@ func TestNotNil(t *testing.T) {
 }
 
 func TestNil(t *testing.T) {
+	t.Parallel()
 
 	Nil(t, nil)
 
@@ -119,6 +126,7 @@ func TestNil(t *testing.T) {
 }
 
 func TestTrue(t *testing.T) {
+	t.Parallel()
 
 	True(t, true)
 
@@ -130,6 +138,7 @@ func TestTrue(t *testing.T) {
 }
 
 func TestFalse(t *testing.T) {
+	t.Parallel()
 
 	False(t, false)
 
@@ -141,6 +150,7 @@ func TestFalse(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
+	t.Parallel()
 
 	Contains(t, "Hello World", "Hello")
 
@@ -152,6 +162,7 @@ func TestContains(t *testing.T) {
 }
 
 func TestNotContains(t *testing.T) {
+	t.Parallel()
 
 	NotContains(t, "Hello World", "Hello!")
 
@@ -163,6 +174,7 @@ func TestNotContains(t *testing.T) {
 }
 
 func TestPanics(t *testing.T) {
+	t.Parallel()
 
 	Panics(t, func() {
 		panic("Panic!")
@@ -176,6 +188,7 @@ func TestPanics(t *testing.T) {
 }
 
 func TestNotPanics(t *testing.T) {
+	t.Parallel()
 
 	NotPanics(t, func() {})
 
@@ -189,6 +202,7 @@ func TestNotPanics(t *testing.T) {
 }
 
 func TestNoError(t *testing.T) {
+	t.Parallel()
 
 	NoError(t, nil)
 
@@ -200,6 +214,7 @@ func TestNoError(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
+	t.Parallel()
 
 	Error(t, errors.New("some error"))
 
@@ -211,6 +226,7 @@ func TestError(t *testing.T) {
 }
 
 func TestErrorContains(t *testing.T) {
+	t.Parallel()
 
 	ErrorContains(t, errors.New("some error: another error"), "some error")
 
@@ -222,6 +238,7 @@ func TestErrorContains(t *testing.T) {
 }
 
 func TestEqualError(t *testing.T) {
+	t.Parallel()
 
 	EqualError(t, errors.New("some error"), "some error")
 
@@ -233,6 +250,7 @@ func TestEqualError(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
+	t.Parallel()
 
 	Empty(t, "")
 
@@ -244,6 +262,7 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestNotEmpty(t *testing.T) {
+	t.Parallel()
 
 	NotEmpty(t, "x")
 
@@ -255,6 +274,7 @@ func TestNotEmpty(t *testing.T) {
 }
 
 func TestWithinDuration(t *testing.T) {
+	t.Parallel()
 
 	a := time.Now()
 	b := a.Add(10 * time.Second)
@@ -269,6 +289,7 @@ func TestWithinDuration(t *testing.T) {
 }
 
 func TestInDelta(t *testing.T) {
+	t.Parallel()
 
 	InDelta(t, 1.001, 1, 0.01)
 
@@ -280,6 +301,7 @@ func TestInDelta(t *testing.T) {
 }
 
 func TestZero(t *testing.T) {
+	t.Parallel()
 
 	Zero(t, "")
 
@@ -291,6 +313,7 @@ func TestZero(t *testing.T) {
 }
 
 func TestNotZero(t *testing.T) {
+	t.Parallel()
 
 	NotZero(t, "x")
 
@@ -302,6 +325,8 @@ func TestNotZero(t *testing.T) {
 }
 
 func TestJSONEq_EqualSONString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
 	if mockT.Failed {
@@ -310,6 +335,8 @@ func TestJSONEq_EqualSONString(t *testing.T) {
 }
 
 func TestJSONEq_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 	if mockT.Failed {
@@ -318,6 +345,8 @@ func TestJSONEq_EquivalentButNotEqual(t *testing.T) {
 }
 
 func TestJSONEq_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
 		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")
@@ -327,6 +356,8 @@ func TestJSONEq_HashOfArraysAndHashes(t *testing.T) {
 }
 
 func TestJSONEq_Array(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
 	if mockT.Failed {
@@ -335,6 +366,8 @@ func TestJSONEq_Array(t *testing.T) {
 }
 
 func TestJSONEq_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
 	if !mockT.Failed {
@@ -343,6 +376,8 @@ func TestJSONEq_HashAndArrayNotEquivalent(t *testing.T) {
 }
 
 func TestJSONEq_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 	if !mockT.Failed {
@@ -351,6 +386,8 @@ func TestJSONEq_HashesNotEquivalent(t *testing.T) {
 }
 
 func TestJSONEq_ActualIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `{"foo": "bar"}`, "Not JSON")
 	if !mockT.Failed {
@@ -359,6 +396,8 @@ func TestJSONEq_ActualIsNotJSON(t *testing.T) {
 }
 
 func TestJSONEq_ExpectedIsNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`)
 	if !mockT.Failed {
@@ -367,6 +406,8 @@ func TestJSONEq_ExpectedIsNotJSON(t *testing.T) {
 }
 
 func TestJSONEq_ExpectedAndActualNotJSON(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, "Not JSON", "Not JSON")
 	if !mockT.Failed {
@@ -375,6 +416,8 @@ func TestJSONEq_ExpectedAndActualNotJSON(t *testing.T) {
 }
 
 func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`)
 	if !mockT.Failed {
@@ -383,6 +426,8 @@ func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
 }
 
 func TestYAMLEq_EqualYAMLString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
 	if mockT.Failed {
@@ -391,6 +436,8 @@ func TestYAMLEq_EqualYAMLString(t *testing.T) {
 }
 
 func TestYAMLEq_EquivalentButNotEqual(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 	if mockT.Failed {
@@ -399,6 +446,8 @@ func TestYAMLEq_EquivalentButNotEqual(t *testing.T) {
 }
 
 func TestYAMLEq_HashOfArraysAndHashes(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	expected := `
 numeric: 1.5
@@ -432,6 +481,8 @@ array:
 }
 
 func TestYAMLEq_Array(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
 	if mockT.Failed {
@@ -440,6 +491,8 @@ func TestYAMLEq_Array(t *testing.T) {
 }
 
 func TestYAMLEq_HashAndArrayNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
 	if !mockT.Failed {
@@ -448,6 +501,8 @@ func TestYAMLEq_HashAndArrayNotEquivalent(t *testing.T) {
 }
 
 func TestYAMLEq_HashesNotEquivalent(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 	if !mockT.Failed {
@@ -456,6 +511,8 @@ func TestYAMLEq_HashesNotEquivalent(t *testing.T) {
 }
 
 func TestYAMLEq_ActualIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `{"foo": "bar"}`, "Simple String")
 	if !mockT.Failed {
@@ -464,6 +521,8 @@ func TestYAMLEq_ActualIsSimpleString(t *testing.T) {
 }
 
 func TestYAMLEq_ExpectedIsSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, "Simple String", `{"foo": "bar", "hello": "world"}`)
 	if !mockT.Failed {
@@ -472,6 +531,8 @@ func TestYAMLEq_ExpectedIsSimpleString(t *testing.T) {
 }
 
 func TestYAMLEq_ExpectedAndActualSimpleString(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, "Simple String", "Simple String")
 	if mockT.Failed {
@@ -480,6 +541,8 @@ func TestYAMLEq_ExpectedAndActualSimpleString(t *testing.T) {
 }
 
 func TestYAMLEq_ArraysOfDifferentOrder(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 	YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`)
 	if !mockT.Failed {
@@ -518,6 +581,8 @@ func ExampleComparisonAssertionFunc() {
 }
 
 func TestComparisonAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	type iface interface {
 		Name() string
 	}
@@ -579,6 +644,8 @@ func ExampleValueAssertionFunc() {
 }
 
 func TestValueAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		value     interface{}
@@ -625,6 +692,8 @@ func ExampleBoolAssertionFunc() {
 }
 
 func TestBoolAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		value     bool
@@ -668,6 +737,8 @@ func ExampleErrorAssertionFunc() {
 }
 
 func TestErrorAssertionFunc(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		err       error
@@ -685,6 +756,8 @@ func TestErrorAssertionFunc(t *testing.T) {
 }
 
 func TestEventuallyWithTFalse(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 
 	condition := func(collect *assert.CollectT) {
@@ -696,6 +769,8 @@ func TestEventuallyWithTFalse(t *testing.T) {
 }
 
 func TestEventuallyWithTTrue(t *testing.T) {
+	t.Parallel()
+
 	mockT := new(MockT)
 
 	counter := 0

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -29,6 +29,9 @@ type MockT struct {
 	Failed bool
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (MockT) Helper() {}
+
 func (t *MockT) FailNow() {
 	t.Failed = true
 }

--- a/suite/stats_test.go
+++ b/suite/stats_test.go
@@ -27,3 +27,14 @@ func TestPassedReturnsFalseWhenSomeTestFails(t *testing.T) {
 
 	assert.False(t, sinfo.Passed())
 }
+
+func TestPassedReturnsFalseWhenAllTestsFail(t *testing.T) {
+	sinfo := newSuiteInformation()
+	sinfo.TestStats = map[string]*TestInformation{
+		"Test1": {TestName: "Test1", Passed: false},
+		"Test2": {TestName: "Test2", Passed: false},
+		"Test3": {TestName: "Test3", Passed: false},
+	}
+
+	assert.False(t, sinfo.Passed())
+}

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// allTestsFilter is a yes filter for testing.RunTests
+func allTestsFilter(pat, str string) (bool, error) {
+	return true, nil
+}
+
 // SuiteRequireTwice is intended to test the usage of suite.Require in two
 // different tests
 type SuiteRequireTwice struct{ Suite }


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `11522a0..0ff4bb4`
**Files Changed:** 12 (12 programming files)
**Programming Ratio:** 100.0%

**Commits included:**
- Merge pull request #1751 from stretchr/dolmen/suite-fix-use-of-testing-internals
- suite: cleanup use of 'testing' internals at runtime
- Merge pull request #1756 from stretchr/dolmen/mock-Parallel-testing
- mock: enable parallel testing on internal testsuite
- assert.YAMLEq: shortcut if same strings
- assert.JSONEq: shortcut if same strings
- Improve usage of Sprintf with Same/NotSame
- Merge pull request #1423 from stretchr/add-Helper-method-in-tests
- assert.CollectT: add Helper() method
- mock/tests: add method Helper() to all mock of *testing.T
... and 5 more commits